### PR TITLE
MKA-292 Prohibit configuring confidentiality offset > 0 in linux daemon, because kernel does not support it

### DIFF
--- a/mkad.conf.example
+++ b/mkad.conf.example
@@ -114,8 +114,6 @@ secy_polling_ms: 500
 #   DISABLE     -> MKA negotiation without MACSEC
 #   INTEGRITY   -> Negotiates MACSEC with integrity only, no confidentiality
 #   CONF_0      -> Negotiates MACSEC with integrity and confidentiality, offset 0
-#   CONF_30     -> Negotiates MACSEC with integrity and confidentiality, offset 30
-#   CONF_50     -> Negotiates MACSEC with integrity and confidentiality, offset 50
 #
 # NOTE: With option DISABLE, please also consider the following two settings are
 #           necessary in order to achieve communication based on MKA authentication:

--- a/src/linux_daemon/mka_daemon_config.c
+++ b/src/linux_daemon/mka_daemon_config.c
@@ -828,20 +828,8 @@ static bool parse_elem_macsec_mode(yaml_parser_t *parser, yaml_event_t *event, t
         cfg->kay.macsec_desired = true;
         cfg->impl.conf_offset_preference = MKA_CONFIDENTIALITY_OFFSET_0;
     }
-    else if (STR_EQUAL("conf_30", event->data.scalar.value)) {
-        cfg->port_capabilities.macsec = true;
-        cfg->kay.macsec_capable = MKA_MACSEC_INT_CONF_0_30_50;
-        cfg->kay.macsec_desired = true;
-        cfg->impl.conf_offset_preference = MKA_CONFIDENTIALITY_OFFSET_30;
-    }
-    else if (STR_EQUAL("conf_50", event->data.scalar.value)) {
-        cfg->port_capabilities.macsec = true;
-        cfg->kay.macsec_capable = MKA_MACSEC_INT_CONF_0_30_50;
-        cfg->kay.macsec_desired = true;
-        cfg->impl.conf_offset_preference = MKA_CONFIDENTIALITY_OFFSET_50;
-    }
     else {
-        FATAL_AT(event, "while importing [%s], value [%s] invalid, possible values {disable, integrity, conf_0, conf_30, conf_50}",
+        FATAL_AT(event, "while importing [%s], value [%s] invalid, possible values {disable, integrity, conf_0}",
                 elem->name, event->data.scalar.value);
         result = false;
     }

--- a/test/daemon/test-yaml-importer.cpp
+++ b/test/daemon/test-yaml-importer.cpp
@@ -910,23 +910,15 @@ TEST_F(TestMacsecLevels, Confidentiality_0) {
 TEST_F(TestMacsecLevels, Confidentiality_30) {
     if0->macsec = "conf_30";
 
-    ASSERT_THAT(import(), Ne(nullptr));
-    EXPECT_THAT(test_config->bus_config[0].port_capabilities.macsec,    Eq(true));
-    EXPECT_THAT(test_config->bus_config[0].kay.macsec_capable,          Eq(MKA_MACSEC_INT_CONF_0_30_50));
-    EXPECT_THAT(test_config->bus_config[0].kay.macsec_desired,          Eq(true));
-    EXPECT_THAT(test_config->bus_config[0].impl.cipher_preference[0],   Ne(MKA_CS_NULL));
-    EXPECT_THAT(test_config->bus_config[0].impl.conf_offset_preference, Eq(MKA_CONFIDENTIALITY_OFFSET_30));
+    EXPECT_CALL(mocks, print_action(LoggingMessageContains("invalid, possible values {disable, integrity, conf_0}"), _));
+    ASSERT_THAT(import(), Eq(nullptr));
 }
 
 TEST_F(TestMacsecLevels, Confidentiality_50) {
     if0->macsec = "conf_50";
 
-    ASSERT_THAT(import(), Ne(nullptr));
-    EXPECT_THAT(test_config->bus_config[0].port_capabilities.macsec,    Eq(true));
-    EXPECT_THAT(test_config->bus_config[0].kay.macsec_capable,          Eq(MKA_MACSEC_INT_CONF_0_30_50));
-    EXPECT_THAT(test_config->bus_config[0].kay.macsec_desired,          Eq(true));
-    EXPECT_THAT(test_config->bus_config[0].impl.cipher_preference[0],   Ne(MKA_CS_NULL));
-    EXPECT_THAT(test_config->bus_config[0].impl.conf_offset_preference, Eq(MKA_CONFIDENTIALITY_OFFSET_50));
+    EXPECT_CALL(mocks, print_action(LoggingMessageContains("invalid, possible values {disable, integrity, conf_0}"), _));
+    ASSERT_THAT(import(), Eq(nullptr));
 }
 
 struct TestUnauthAllowedValues : public BasicTest, public ::testing::WithParamInterface<std::tuple<char const*, t_MKA_unauth_allow>> { };


### PR DESCRIPTION
MKA-292  Prohibit conf_30 and conf_50 configuration for confidentiality offset since it is not supported by Linux Kernel